### PR TITLE
chore: raise PHPStan to level 9

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ This file outlines the requirements and best practices for adding new assertion 
 ## Validation Steps
 
 - **Run Tests**: Execute `./vendor/bin/phpunit tests/FluentAssertions/Asserts/MethodName/MethodNameTest.php` to verify implementation.
-- **Lint and Typecheck**: Run PHPStan static analysis via `composer run analyze` to ensure code quality.
+- **Lint and Typecheck**: Run PHPStan static analysis via `composer phpstan` to ensure code quality.
 - **Integration**: Ensure the method works in the overall fluent chain without breaking existing functionality.
 
 ## Example Workflow for Adding `isGreaterThan`

--- a/composer.json
+++ b/composer.json
@@ -38,14 +38,13 @@
    },
    "minimum-stability": "stable",
    "scripts": {
-    "analyze": [
-      "@phpstan"
-    ],
-      "phpstan": "./vendor/bin/phpstan analyse",
+      "test": "phpunit",
+      "phpstan": "phpstan analyse",
       "cs": "pint --test",
       "cs-fix": "pint",
       "check": [
-        "@analyze",
+        "@test",
+        "@phpstan",
         "@cs"
       ]
    },

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,4 @@
 parameters:
-    level: 5
+    level: 9
     paths:
         - src
-    excludePaths:
-        - vendor

--- a/src/Traits/ArrayAssertions.php
+++ b/src/Traits/ArrayAssertions.php
@@ -6,6 +6,8 @@ namespace K2gl\PHPUnitFluentAssertions\Traits;
 
 use K2gl\PHPUnitFluentAssertions\FluentAssertions;
 use PHPUnit\Framework\Assert;
+use ArrayAccess;
+use Countable;
 
 /**
  * @phpstan-require-extends FluentAssertions
@@ -28,6 +30,10 @@ trait ArrayAssertions
      */
     public function count(int $expectedCount, string $message = ''): self
     {
+        if (! is_iterable($this->variable) && ! $this->variable instanceof Countable) {
+            Assert::fail($message ?: 'Variable is not countable.');
+        }
+
         Assert::assertCount($expectedCount, $this->variable, $message);
 
         return $this;
@@ -49,6 +55,10 @@ trait ArrayAssertions
      */
     public function notCount(int $elementsCount, string $message = ''): self
     {
+        if (! is_iterable($this->variable) && ! $this->variable instanceof Countable) {
+            Assert::fail($message ?: 'Variable is not countable.');
+        }
+
         Assert::assertNotCount($elementsCount, $this->variable, $message);
 
         return $this;
@@ -63,12 +73,16 @@ trait ArrayAssertions
      * fact(['a' => ['b' => 'c']])->arrayContainsAssociativeArray(['a' => ['b' => 'c']]); // Passes
      * fact(['a' => ['b' => 'd']])->arrayContainsAssociativeArray(['a' => ['b' => 'c']]); // Fails
      *
-     * @param array $values The associative array that should be contained within the actual array.
+     * @param array<array-key, mixed> $values The associative array that should be contained within the actual array.
      *
       * @return self Enables fluent chaining of assertion methods.
      */
     public function arrayContainsAssociativeArray(array $values): self
     {
+        if (! is_array($this->variable)) {
+            Assert::fail('Variable is not an array.');
+        }
+
         Assert::assertTrue(
             $this->arrayContainsAssociativeArrayRecursive($this->variable, $values),
             sprintf(
@@ -81,14 +95,20 @@ trait ArrayAssertions
         return $this;
     }
 
+    /**
+     * @param array<array-key, mixed> $data
+     * @param array<array-key, mixed> $values
+     */
     protected function arrayContainsAssociativeArrayRecursive(array $data, array $values): bool
     {
         foreach ($values as $key => $value) {
+            $actual = $data[$key] ?? null;
+
             if (is_array($value)) {
-                if (! $this->arrayContainsAssociativeArrayRecursive($data[$key], $value)) {
+                if (! is_array($actual) || ! $this->arrayContainsAssociativeArrayRecursive($actual, $value)) {
                     return false;
                 }
-            } elseif ($data[$key] !== $value) {
+            } elseif ($actual !== $value) {
                 return false;
             }
         }
@@ -112,6 +132,10 @@ trait ArrayAssertions
      */
     public function arrayHasKey(int|string $key, string $message = ''): self
     {
+        if (! is_array($this->variable) && ! $this->variable instanceof ArrayAccess) {
+            Assert::fail($message ?: 'Variable is not an array or ArrayAccess.');
+        }
+
         Assert::assertArrayHasKey($key, $this->variable, $message);
 
         return $this;
@@ -133,6 +157,10 @@ trait ArrayAssertions
      */
     public function arrayNotHasKey(int|string $key, string $message = ''): self
     {
+        if (! is_array($this->variable) && ! $this->variable instanceof ArrayAccess) {
+            Assert::fail($message ?: 'Variable is not an array or ArrayAccess.');
+        }
+
         Assert::assertArrayNotHasKey($key, $this->variable, $message);
 
         return $this;
@@ -154,6 +182,10 @@ trait ArrayAssertions
      */
     public function contains(mixed $value, string $message = ''): self
     {
+        if (! is_iterable($this->variable)) {
+            Assert::fail($message ?: 'Variable is not iterable.');
+        }
+
         Assert::assertContains($value, $this->variable, $message);
 
         return $this;
@@ -175,6 +207,10 @@ trait ArrayAssertions
      */
     public function doesNotContain(mixed $value, string $message = ''): self
     {
+        if (! is_iterable($this->variable)) {
+            Assert::fail($message ?: 'Variable is not iterable.');
+        }
+
         Assert::assertNotContains($value, $this->variable, $message);
 
         return $this;
@@ -196,6 +232,10 @@ trait ArrayAssertions
      */
     public function hasSize(int $size, string $message = ''): self
     {
+        if (! is_iterable($this->variable) && ! $this->variable instanceof Countable) {
+            Assert::fail($message ?: 'Variable is not countable.');
+        }
+
         Assert::assertCount($size, $this->variable, $message);
 
         return $this;
@@ -216,6 +256,10 @@ trait ArrayAssertions
      */
     public function isEmptyArray(string $message = ''): self
     {
+        if (! is_iterable($this->variable) && ! $this->variable instanceof Countable) {
+            Assert::fail($message ?: 'Variable is not countable.');
+        }
+
         Assert::assertCount(0, $this->variable, $message);
 
         return $this;
@@ -236,6 +280,10 @@ trait ArrayAssertions
      */
     public function isNotEmptyArray(string $message = ''): self
     {
+        if (! is_iterable($this->variable) && ! $this->variable instanceof Countable) {
+            Assert::fail($message ?: 'Variable is not countable.');
+        }
+
         Assert::assertNotCount(0, $this->variable, $message);
 
         return $this;

--- a/src/Traits/NumericAssertions.php
+++ b/src/Traits/NumericAssertions.php
@@ -144,6 +144,10 @@ trait NumericAssertions
      */
     public function isBetween(int|float $min, int|float $max, string $message = ''): self
     {
+        if (! is_int($this->variable) && ! is_float($this->variable)) {
+            Assert::fail($message ?: 'Variable is not numeric.');
+        }
+
         Assert::assertTrue(
             $this->variable >= $min && $this->variable <= $max,
             $message ?: sprintf(

--- a/src/Traits/StringAssertions.php
+++ b/src/Traits/StringAssertions.php
@@ -35,6 +35,10 @@ trait StringAssertions
             Assert::fail('Pattern cannot be an empty string.');
         }
 
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
+        }
+
         Assert::assertMatchesRegularExpression($pattern, $this->variable, $message);
 
         return $this;
@@ -58,6 +62,10 @@ trait StringAssertions
     {
         if (strlen($pattern) === 0) {
             Assert::fail('Pattern cannot be an empty string.');
+        }
+
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
         }
 
         Assert::assertDoesNotMatchRegularExpression($pattern, $this->variable, $message);
@@ -89,6 +97,10 @@ trait StringAssertions
             Assert::fail('String cannot be an empty.');
         }
 
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
+        }
+
         Assert::assertStringContainsString($string, $this->variable, $message);
 
         return $this;
@@ -112,6 +124,10 @@ trait StringAssertions
     {
         if (strlen($string) === 0) {
             Assert::fail('String cannot be an empty.');
+        }
+
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
         }
 
         Assert::assertStringNotContainsString($string, $this->variable, $message);
@@ -139,6 +155,10 @@ trait StringAssertions
             Assert::fail('String cannot be an empty.');
         }
 
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
+        }
+
         Assert::assertStringContainsStringIgnoringCase($string, $this->variable, $message);
 
         return $this;
@@ -162,6 +182,10 @@ trait StringAssertions
     {
         if (strlen($string) === 0) {
             Assert::fail('String cannot be an empty.');
+        }
+
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
         }
 
         Assert::assertStringNotContainsStringIgnoringCase(
@@ -197,6 +221,10 @@ trait StringAssertions
             Assert::fail('Prefix cannot be an empty string.');
         }
 
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
+        }
+
         /** @var non-empty-string $prefix */
         Assert::assertStringStartsWith($prefix, $this->variable, $message);
 
@@ -221,6 +249,10 @@ trait StringAssertions
     {
         if (strlen($suffix) === 0) {
             Assert::fail('Suffix cannot be an empty string.');
+        }
+
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
         }
 
         /** @var non-empty-string $suffix */
@@ -249,6 +281,10 @@ trait StringAssertions
      */
     public function hasLength(int $length, string $message = ''): self
     {
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
+        }
+
         Assert::assertEquals($length, strlen($this->variable), $message);
 
         return $this;
@@ -309,6 +345,10 @@ trait StringAssertions
      */
     public function isJson(string $message = ''): self
     {
+        if (! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not a string.');
+        }
+
         Assert::assertTrue(json_validate($this->variable), $message ?: 'String is not valid JSON.');
 
         return $this;

--- a/src/Traits/TypeCheckingAssertions.php
+++ b/src/Traits/TypeCheckingAssertions.php
@@ -21,12 +21,12 @@ trait TypeCheckingAssertions
      * fact(new stdClass())->instanceOf(stdClass::class); // Passes
      * fact(new stdClass())->instanceOf(Exception::class); // Fails
      *
-     * @param mixed $expected The class or interface name.
+     * @param class-string $expected The class or interface name.
      * @param string $message Optional custom error message.
      *
      * @return self  Enables fluent chaining of assertion methods.
      */
-    public function instanceOf(mixed $expected, string $message = ''): self
+    public function instanceOf(string $expected, string $message = ''): self
     {
         Assert::assertInstanceOf($expected, $this->variable, $message);
 
@@ -42,12 +42,12 @@ trait TypeCheckingAssertions
      * fact(new stdClass())->notInstanceOf(Exception::class); // Passes
      * fact(new stdClass())->notInstanceOf(stdClass::class); // Fails
      *
-     * @param mixed $expected The class or interface name that should not match.
+     * @param class-string $expected The class or interface name that should not match.
      * @param string $message Optional custom error message.
      *
      * @return self  Enables fluent chaining of assertion methods.
      */
-    public function notInstanceOf(mixed $expected, string $message = ''): self
+    public function notInstanceOf(string $expected, string $message = ''): self
     {
         Assert::assertNotInstanceOf($expected, $this->variable, $message);
 
@@ -110,6 +110,10 @@ trait TypeCheckingAssertions
      */
     public function hasProperty(string $property, string $message = ''): self
     {
+        if (! is_object($this->variable)) {
+            Assert::fail($message ?: 'Variable is not an object.');
+        }
+
         Assert::assertObjectHasProperty($property, $this->variable, $message);
 
         return $this;
@@ -131,6 +135,10 @@ trait TypeCheckingAssertions
      */
     public function hasMethod(string $method, string $message = ''): self
     {
+        if (! is_object($this->variable) && ! is_string($this->variable)) {
+            Assert::fail($message ?: 'Variable is not an object or a class name.');
+        }
+
         Assert::assertTrue(method_exists($this->variable, $method), $message ?: "Object does not have method '$method'.");
 
         return $this;


### PR DESCRIPTION
Raise PHPStan from level 5 to 9 (matching the rest of the collection).

Guard mixed values with their expected type before the typed PHPUnit assertions, and tighten `instanceOf()` to `class-string`. Also align the Composer scripts (`test`, `check`) with the other packages.