### PR TITLE
ci: add PHP 8.5 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         # The library runtime targets PHP 8.1+, but the test suite uses PHPUnit 11.4+
         # metadata (#[CoversMethod]) which requires PHP 8.2+. PHP 8.1 is covered by the
         # separate source-php81 job below (install + static analysis).
-        php-version: ['8.2', '8.3', '8.4']
+        php-version: ['8.2', '8.3', '8.4', '8.5']
 
     name: PHP ${{ matrix.php-version }}
 


### PR DESCRIPTION
PHP 8.5 has been GA since November 2025. Add it to the CI matrix; the package already targets `>=8.1`, so no constraint change is needed.