### PR TITLE
chore: export-ignore phpstan.neon from the dist archive

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,4 +4,5 @@
 pint.json export-ignore
 tests/ export-ignore
 phpunit.xml export-ignore
+phpstan.neon export-ignore
 rector.php export-ignore


### PR DESCRIPTION
`phpstan.neon` is the package's own dev analysis config and should not ship. The consumer-facing `extension.neon` (wired via `extra.phpstan.includes`) still ships.