### PR TITLE
ci: attest release tarballs with build provenance

### DIFF
--- a/.github/workflows/attest.yml
+++ b/.github/workflows/attest.yml
@@ -1,0 +1,38 @@
+name: Attest
+
+on:
+  workflow_dispatch:
+  push:
+    tags: ['*']
+
+permissions:
+  id-token: write
+  attestations: write
+  contents: read
+
+jobs:
+  attest:
+    name: Build provenance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Build release tarball
+        run: |
+          version="${GITHUB_REF_NAME//\//-}"
+          tarball="phpunit-fluent-assertions-${version}.tar.gz"
+          git archive --format=tar.gz --prefix="phpunit-fluent-assertions-${version}/" --output="${tarball}" "${GITHUB_SHA}"
+          echo "tarball=${tarball}" >> "$GITHUB_ENV"
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: ${{ env.tarball }}
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v7
+        with:
+          name: tarball
+          path: ${{ env.tarball }}


### PR DESCRIPTION
Adds an Attest workflow: builds a deterministic release tarball with git archive and signs SLSA build provenance for it via actions/attest-build-provenance (Sigstore keyless). Runs on tag pushes; workflow_dispatch kept for manual runs.