### PR TITLE
feat: exception, date/time and enum assertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+All notable changes to this package are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [12.8.0] - 2026-06-13
+
+### Added
+
+- Exception assertion `throws()` — invokes a callable subject and asserts the
+  expected exception is thrown, optionally matching a message substring.
+- Date/time assertions `isBefore()`, `isAfter()`, `isSameDate()` for a
+  `DateTimeInterface` subject (string expectations are parsed).
+- Enum assertions `isEnum()`, `hasValue()`, `hasName()` for native
+  `UnitEnum` / `BackedEnum` subjects.
+
+## [12.7.0] - 2026-06-05
+
+### Changed
+
+- Adopted Laravel Pint for code style, raised PHPStan analysis to level 9, and
+  added shields.io badges and a combined check script.
+
+## [12.6.0] - 2026-05-27
+
+### Added
+
+- Extended the PHPStan type-specifying extension to narrow every type check
+  (`isString`, `isInt`, `isFloat`, `isBool`, `isArray`, `isCallable`,
+  `isResource`).
+
+### Changed
+
+- Fixed latent static-analysis errors and ran the CI matrix across PHP 8.2–8.5
+  (with a PHP 8.1 source/static-analysis job).
+
+[12.8.0]: https://github.com/k2gl/phpunit-fluent-assertions/compare/12.7.0...12.8.0
+[12.7.0]: https://github.com/k2gl/phpunit-fluent-assertions/compare/12.6.0...12.7.0
+[12.6.0]: https://github.com/k2gl/phpunit-fluent-assertions/compare/12.5.0...12.6.0

--- a/README.md
+++ b/README.md
@@ -226,6 +226,31 @@ fact(true)->isBool(); // Passes
 fact(1)->isBool(); // Fails
 ```
 
+### Exception assertions
+The subject is a callable; `throws()` invokes it and asserts the expected exception is thrown.
+Pass a message substring to also assert on the exception message.
+```php
+fact(fn () => throw new RuntimeException('boom'))->throws(RuntimeException::class); // Passes
+fact(fn () => $service->run())->throws(DomainException::class, 'invalid'); // Passes if message contains "invalid"
+fact(fn () => 42)->throws(RuntimeException::class); // Fails — nothing thrown
+```
+
+### Date/time assertions
+The subject is a `DateTimeInterface`; a string expectation is parsed as a `DateTimeImmutable`.
+```php
+fact(new DateTimeImmutable('2024-01-01'))->isBefore('2024-12-31'); // Passes
+fact(new DateTimeImmutable('2024-12-31'))->isAfter('2024-01-01'); // Passes
+fact(new DateTimeImmutable('2024-06-13 23:59'))->isSameDate('2024-06-13'); // Passes — same calendar date, time ignored
+```
+
+### Enum assertions
+Work on any native `UnitEnum` / `BackedEnum`.
+```php
+fact($order->status)->isEnum(Status::Paid);   // identity: the subject is that case
+fact(Status::Paid)->hasValue('paid');          // BackedEnum backing value
+fact(Status::Paid)->hasName('Paid');           // case name
+```
+
 ## PHPStan support
 
 The package ships a PHPStan extension that narrows the asserted value, so the analyser

--- a/src/FluentAssertions.php
+++ b/src/FluentAssertions.php
@@ -7,6 +7,9 @@ namespace K2gl\PHPUnitFluentAssertions;
 use K2gl\PHPUnitFluentAssertions\Traits\ArrayAssertions;
 use K2gl\PHPUnitFluentAssertions\Traits\BooleanAssertions;
 use K2gl\PHPUnitFluentAssertions\Traits\ComparisonAndEqualityAssertions;
+use K2gl\PHPUnitFluentAssertions\Traits\DateTimeAssertions;
+use K2gl\PHPUnitFluentAssertions\Traits\EnumAssertions;
+use K2gl\PHPUnitFluentAssertions\Traits\ExceptionAssertions;
 use K2gl\PHPUnitFluentAssertions\Traits\NullAssertions;
 use K2gl\PHPUnitFluentAssertions\Traits\NumericAssertions;
 use K2gl\PHPUnitFluentAssertions\Traits\StringAssertions;
@@ -21,6 +24,9 @@ class FluentAssertions
     use StringAssertions;
     use ArrayAssertions;
     use TypeCheckingAssertions;
+    use ExceptionAssertions;
+    use DateTimeAssertions;
+    use EnumAssertions;
 
     public function __construct(
         public readonly mixed $variable = null

--- a/src/Traits/DateTimeAssertions.php
+++ b/src/Traits/DateTimeAssertions.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Traits;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use PHPUnit\Framework\Assert;
+
+/**
+ * @phpstan-require-extends \K2gl\PHPUnitFluentAssertions\FluentAssertions
+ */
+trait DateTimeAssertions
+{
+    /**
+     * Asserts that the subject (a DateTimeInterface) is strictly before the
+     * expected moment. A string expectation is parsed as a DateTimeImmutable.
+     *
+     * Example usage:
+     * fact(new DateTimeImmutable('2024-01-01'))->isBefore('2024-12-31');
+     */
+    public function isBefore(DateTimeInterface|string $expected, string $message = ''): self
+    {
+        Assert::assertLessThan($this->toDateTime($expected), $this->subjectDateTime(), $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the subject (a DateTimeInterface) is strictly after the
+     * expected moment. A string expectation is parsed as a DateTimeImmutable.
+     */
+    public function isAfter(DateTimeInterface|string $expected, string $message = ''): self
+    {
+        Assert::assertGreaterThan($this->toDateTime($expected), $this->subjectDateTime(), $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the subject falls on the same calendar date (Y-m-d) as the
+     * expected moment, ignoring the time of day.
+     */
+    public function isSameDate(DateTimeInterface|string $expected, string $message = ''): self
+    {
+        Assert::assertSame(
+            $this->toDateTime($expected)->format('Y-m-d'),
+            $this->subjectDateTime()->format('Y-m-d'),
+            $message,
+        );
+
+        return $this;
+    }
+
+    private function subjectDateTime(): DateTimeInterface
+    {
+        $subject = $this->variable;
+
+        if (! $subject instanceof DateTimeInterface) {
+            Assert::fail('This assertion expects the subject to be a DateTimeInterface.');
+        }
+
+        return $subject;
+    }
+
+    private function toDateTime(DateTimeInterface|string $value): DateTimeInterface
+    {
+        return is_string($value) ? new DateTimeImmutable($value) : $value;
+    }
+}

--- a/src/Traits/EnumAssertions.php
+++ b/src/Traits/EnumAssertions.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Traits;
+
+use BackedEnum;
+use PHPUnit\Framework\Assert;
+use UnitEnum;
+
+/**
+ * Soft integration with enums — works on any native UnitEnum / BackedEnum,
+ * without depending on k2gl/enum.
+ *
+ * @phpstan-require-extends \K2gl\PHPUnitFluentAssertions\FluentAssertions
+ */
+trait EnumAssertions
+{
+    /**
+     * Asserts that the subject is the given enum case (identity).
+     *
+     * Example usage:
+     * fact($order->status)->isEnum(Status::Paid);
+     */
+    public function isEnum(UnitEnum $case, string $message = ''): self
+    {
+        Assert::assertSame($case, $this->variable, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the subject is a BackedEnum whose backing value equals `$value`.
+     */
+    public function hasValue(int|string $value, string $message = ''): self
+    {
+        $subject = $this->variable;
+
+        if (! $subject instanceof BackedEnum) {
+            Assert::fail('hasValue() expects the subject to be a BackedEnum.');
+        }
+
+        Assert::assertSame($value, $subject->value, $message);
+
+        return $this;
+    }
+
+    /**
+     * Asserts that the subject is an enum whose case name equals `$name`.
+     */
+    public function hasName(string $name, string $message = ''): self
+    {
+        $subject = $this->variable;
+
+        if (! $subject instanceof UnitEnum) {
+            Assert::fail('hasName() expects the subject to be an enum.');
+        }
+
+        Assert::assertSame($name, $subject->name, $message);
+
+        return $this;
+    }
+}

--- a/src/Traits/ExceptionAssertions.php
+++ b/src/Traits/ExceptionAssertions.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Traits;
+
+use PHPUnit\Framework\Assert;
+use Throwable;
+
+/**
+ * @phpstan-require-extends \K2gl\PHPUnitFluentAssertions\FluentAssertions
+ */
+trait ExceptionAssertions
+{
+    /**
+     * Asserts that calling the subject (a callable) throws the given exception.
+     *
+     * Pass a non-empty `$message` to also assert that the thrown message contains
+     * that substring.
+     *
+     * Example usage:
+     * fact(fn () => throw new RuntimeException('boom'))->throws(RuntimeException::class);
+     * fact(fn () => $service->run())->throws(DomainException::class, 'invalid');
+     *
+     * @param class-string<Throwable> $exception
+     */
+    public function throws(string $exception, string $message = ''): self
+    {
+        $subject = $this->variable;
+
+        if (! is_callable($subject)) {
+            Assert::fail('throws() expects the subject to be a callable.');
+        }
+
+        try {
+            $subject();
+        } catch (Throwable $thrown) {
+            Assert::assertInstanceOf($exception, $thrown);
+
+            if ($message !== '') {
+                Assert::assertStringContainsString($message, $thrown->getMessage());
+            }
+
+            return $this;
+        }
+
+        Assert::fail(sprintf('Failed asserting that "%s" was thrown.', $exception));
+    }
+}

--- a/tests/Fixtures/Status.php
+++ b/tests/Fixtures/Status.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\Fixtures;
+
+enum Status: string
+{
+    case Pending = 'pending';
+    case Paid = 'paid';
+    case Shipped = 'shipped';
+}

--- a/tests/FluentAssertions/Asserts/HasName/HasNameTest.php
+++ b/tests/FluentAssertions/Asserts/HasName/HasNameTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\Asserts\HasName;
+
+use K2gl\PHPUnitFluentAssertions\FluentAssertions;
+use K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\FluentAssertionsTestCase;
+use K2gl\PHPUnitFluentAssertions\Tests\Fixtures\Status;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+use function K2gl\PHPUnitFluentAssertions\fact;
+
+#[CoversMethod(className: FluentAssertions::class, methodName: 'hasName')]
+final class HasNameTest extends FluentAssertionsTestCase
+{
+    public function testHasCaseName(): void
+    {
+        // act
+        fact(Status::Paid)->hasName('Paid');
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testFailsOnWrongName(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(Status::Paid)->hasName('Pending');
+    }
+
+    public function testFailsWhenSubjectIsNotEnum(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact('Paid')->hasName('Paid');
+    }
+}

--- a/tests/FluentAssertions/Asserts/HasValue/HasValueTest.php
+++ b/tests/FluentAssertions/Asserts/HasValue/HasValueTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\Asserts\HasValue;
+
+use K2gl\PHPUnitFluentAssertions\FluentAssertions;
+use K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\FluentAssertionsTestCase;
+use K2gl\PHPUnitFluentAssertions\Tests\Fixtures\Status;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+use function K2gl\PHPUnitFluentAssertions\fact;
+
+#[CoversMethod(className: FluentAssertions::class, methodName: 'hasValue')]
+final class HasValueTest extends FluentAssertionsTestCase
+{
+    public function testHasBackingValue(): void
+    {
+        // act
+        fact(Status::Paid)->hasValue('paid');
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testFailsOnWrongValue(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(Status::Paid)->hasValue('pending');
+    }
+
+    public function testFailsWhenSubjectIsNotBackedEnum(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact('paid')->hasValue('paid');
+    }
+}

--- a/tests/FluentAssertions/Asserts/IsAfter/IsAfterTest.php
+++ b/tests/FluentAssertions/Asserts/IsAfter/IsAfterTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\Asserts\IsAfter;
+
+use DateTimeImmutable;
+use K2gl\PHPUnitFluentAssertions\FluentAssertions;
+use K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\FluentAssertionsTestCase;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+use function K2gl\PHPUnitFluentAssertions\fact;
+
+#[CoversMethod(className: FluentAssertions::class, methodName: 'isAfter')]
+final class IsAfterTest extends FluentAssertionsTestCase
+{
+    public function testIsAfterStringExpectation(): void
+    {
+        // act
+        fact(new DateTimeImmutable('2024-12-31'))->isAfter('2024-01-01');
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testFailsWhenNotAfter(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(new DateTimeImmutable('2024-01-01'))->isAfter('2024-12-31');
+    }
+
+    public function testFailsWhenSubjectIsNotDateTime(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(42)->isAfter('2024-01-01');
+    }
+}

--- a/tests/FluentAssertions/Asserts/IsBefore/IsBeforeTest.php
+++ b/tests/FluentAssertions/Asserts/IsBefore/IsBeforeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\Asserts\IsBefore;
+
+use DateTimeImmutable;
+use K2gl\PHPUnitFluentAssertions\FluentAssertions;
+use K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\FluentAssertionsTestCase;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+use function K2gl\PHPUnitFluentAssertions\fact;
+
+#[CoversMethod(className: FluentAssertions::class, methodName: 'isBefore')]
+final class IsBeforeTest extends FluentAssertionsTestCase
+{
+    public function testIsBeforeStringExpectation(): void
+    {
+        // act
+        fact(new DateTimeImmutable('2024-01-01'))->isBefore('2024-12-31');
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testIsBeforeDateTimeExpectation(): void
+    {
+        // act
+        fact(new DateTimeImmutable('2024-01-01 10:00:00'))->isBefore(new DateTimeImmutable('2024-01-01 11:00:00'));
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testFailsWhenNotBefore(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(new DateTimeImmutable('2025-01-01'))->isBefore('2024-12-31');
+    }
+
+    public function testFailsWhenSubjectIsNotDateTime(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact('2024-01-01')->isBefore('2024-12-31');
+    }
+}

--- a/tests/FluentAssertions/Asserts/IsEnum/IsEnumTest.php
+++ b/tests/FluentAssertions/Asserts/IsEnum/IsEnumTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\Asserts\IsEnum;
+
+use K2gl\PHPUnitFluentAssertions\FluentAssertions;
+use K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\FluentAssertionsTestCase;
+use K2gl\PHPUnitFluentAssertions\Tests\Fixtures\Status;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+use function K2gl\PHPUnitFluentAssertions\fact;
+
+#[CoversMethod(className: FluentAssertions::class, methodName: 'isEnum')]
+final class IsEnumTest extends FluentAssertionsTestCase
+{
+    public function testIsExpectedCase(): void
+    {
+        // act
+        fact(Status::Paid)->isEnum(Status::Paid);
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testFailsOnDifferentCase(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(Status::Paid)->isEnum(Status::Pending);
+    }
+
+    public function testFailsWhenSubjectIsBackingValue(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact('paid')->isEnum(Status::Paid);
+    }
+}

--- a/tests/FluentAssertions/Asserts/IsSameDate/IsSameDateTest.php
+++ b/tests/FluentAssertions/Asserts/IsSameDate/IsSameDateTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\Asserts\IsSameDate;
+
+use DateTimeImmutable;
+use K2gl\PHPUnitFluentAssertions\FluentAssertions;
+use K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\FluentAssertionsTestCase;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+use function K2gl\PHPUnitFluentAssertions\fact;
+
+#[CoversMethod(className: FluentAssertions::class, methodName: 'isSameDate')]
+final class IsSameDateTest extends FluentAssertionsTestCase
+{
+    public function testSameCalendarDateIgnoringTime(): void
+    {
+        // act
+        fact(new DateTimeImmutable('2024-06-13 23:59:00'))->isSameDate('2024-06-13 00:00:01');
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testFailsOnDifferentDate(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(new DateTimeImmutable('2024-06-13'))->isSameDate('2024-06-14');
+    }
+
+    public function testFailsWhenSubjectIsNotDateTime(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact('2024-06-13')->isSameDate('2024-06-13');
+    }
+}

--- a/tests/FluentAssertions/Asserts/Throws/ThrowsTest.php
+++ b/tests/FluentAssertions/Asserts/Throws/ThrowsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\Asserts\Throws;
+
+use DomainException;
+use K2gl\PHPUnitFluentAssertions\FluentAssertions;
+use K2gl\PHPUnitFluentAssertions\Tests\FluentAssertions\FluentAssertionsTestCase;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use RuntimeException;
+
+use function K2gl\PHPUnitFluentAssertions\fact;
+
+#[CoversMethod(className: FluentAssertions::class, methodName: 'throws')]
+final class ThrowsTest extends FluentAssertionsTestCase
+{
+    public function testThrowsExpectedException(): void
+    {
+        // act
+        fact(static fn () => throw new RuntimeException('boom'))->throws(RuntimeException::class);
+
+        // assert
+        $this->correctAssertionExecuted();
+    }
+
+    public function testThrowsWithMessageSubstring(): void
+    {
+        // act
+        fact(static fn () => throw new DomainException('value is invalid'))
+            ->throws(DomainException::class, 'invalid');
+
+        // assert
+        $this->correctAssertionsExecuted(expected: 2);
+    }
+
+    public function testFailsWhenWrongExceptionType(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(static fn () => throw new RuntimeException('boom'))->throws(DomainException::class);
+    }
+
+    public function testFailsWhenNothingThrown(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact(static fn () => 42)->throws(RuntimeException::class);
+    }
+
+    public function testFailsWhenSubjectIsNotCallable(): void
+    {
+        // assert
+        $this->incorrectAssertionExpected();
+
+        // act
+        fact('not callable')->throws(RuntimeException::class);
+    }
+}


### PR DESCRIPTION
Roadmap R10, targeting 12.8.0 — the last open item of the 10-release plan.

- `throws(class-string, message = '')` — invokes a callable subject and asserts the expected exception is thrown, optionally matching a message substring.
- `isBefore()` / `isAfter()` / `isSameDate()` — for a `DateTimeInterface` subject; string expectations are parsed as `DateTimeImmutable`. `isSameDate()` compares the calendar date (Y-m-d), ignoring time.
- `isEnum()` / `hasValue()` / `hasName()` — soft enum integration over native `UnitEnum`/`BackedEnum` (no dependency on k2gl/enum).

Three new traits wired into `FluentAssertions`. BC-safe (additive). README updated; CHANGELOG added (backfilled to 12.6.0). Tests follow the per-assert convention; full suite green (424 tests).