### PR TITLE
chore: add community health files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,50 @@
+name: Bug report
+description: Report a problem with the package
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill in the fields below.
+  - type: input
+    id: package-version
+    attributes:
+      label: Package version
+      description: Which version of the package are you using?
+      placeholder: e.g. 12.8.0
+    validations:
+      required: true
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP version
+      placeholder: e.g. 8.3.0
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      description: A minimal code sample or steps that reproduce the issue.
+      render: php
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report Code of Conduct or abuse
+    url: https://github.com/contact/report-abuse
+    about: Report conduct violations or abuse to GitHub Support.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: Suggest an idea or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve? What is the use case?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you would like to happen.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative solutions or features you considered.
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,12 @@
+## Summary
+
+<!-- What does this change, and why? -->
+
+Closes #
+
+## Checklist
+
+- [ ] `composer check` is green (tests, PHPStan, and code style)
+- [ ] Tests added or updated for the change
+- [ ] CHANGELOG.md updated for user-facing changes
+- [ ] No breaking changes (or called out and targeted at a new major)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at GitHub via https://github.com/contact/report-abuse. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for taking the time to contribute! This document describes how to propose
+changes to this package.
+
+## Requirements
+
+- PHP 8.1 or higher to use the package.
+- The test suite requires PHP 8.2+ (it relies on PHPUnit attribute metadata available
+  from PHP 8.2). PHP 8.1 is still covered in CI for installation and static analysis.
+- [Composer](https://getcomposer.org/).
+
+## Getting started
+
+```bash
+git clone https://github.com/k2gl/phpunit-fluent-assertions.git
+cd phpunit-fluent-assertions
+composer install
+```
+
+## Running the checks
+
+A single command runs the full gate — tests, static analysis, and code style:
+
+```bash
+composer check
+```
+
+You can also run each step on its own:
+
+```bash
+composer test      # PHPUnit
+composer phpstan   # static analysis
+composer cs        # code-style check (dry run)
+composer cs-fix    # apply code-style fixes
+```
+
+Please make sure `composer check` passes before opening a pull request. CI runs the
+same checks across PHP 8.1–8.5.
+
+## Coding standards
+
+- Follow the existing code style; run `composer cs-fix` to format your changes.
+- Keep changes focused, and add tests for new behavior and bug fixes.
+
+## Submitting changes
+
+1. Create a branch off `main`.
+2. Make your change with tests, and keep `composer check` green.
+3. Write clear commit messages ([Conventional Commits](https://www.conventionalcommits.org/)
+   are appreciated).
+4. Update `CHANGELOG.md` for user-facing changes.
+5. Open a pull request and fill in the template: describe what changes and why, and
+   link any related issue.
+
+## Reporting bugs and requesting features
+
+Use the issue templates (Bug report / Feature request). For security issues, please
+follow the [security policy](SECURITY.md) rather than opening a public issue.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,22 @@
+# Security Policy
+
+## Supported versions
+
+The latest released version of this package receives security fixes. Please make sure
+you are on the most recent release before reporting an issue.
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities privately — not in a public issue or pull
+request.
+
+Use GitHub's private vulnerability reporting: open the **Security** tab of this
+repository and click **Report a vulnerability**. This opens a private security advisory
+visible only to the maintainers.
+
+Please include enough detail to reproduce the issue: the affected version, your
+environment, and a minimal proof of concept if possible. You can expect an initial
+response within a reasonable time, and we will keep you informed as the report is
+investigated and resolved.
+
+Thank you for helping keep the project and its users safe.


### PR DESCRIPTION
Adds a code of conduct (Contributor Covenant 2.1), contributing guide, security policy, and issue/PR templates. Brings the repository's GitHub community profile to 100%.